### PR TITLE
Content Page Form

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -25,7 +25,5 @@ if (rex::isBackend()) {
         $ersetzen = rex_config::get("stellenangebote", "editor");
         $ep->setSubject(str_replace($suchmuster, $ersetzen, $ep->getSubject()));
     });
-    if(rex_be_controller::getPageObject('content')) {
-        stellenangebote::addContentPage();
-    }
+    stellenangebote::addContentPage();
 }

--- a/boot.php
+++ b/boot.php
@@ -25,4 +25,7 @@ if (rex::isBackend()) {
         $ersetzen = rex_config::get("stellenangebote", "editor");
         $ep->setSubject(str_replace($suchmuster, $ersetzen, $ep->getSubject()));
     });
+    if(rex_be_controller::getPageObject('content')) {
+        stellenangebote::addContentPage();
+    }
 }

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -9,6 +9,9 @@ stellenangebote_entry = Stellenangebote
 
 stellenangebote_apply_message = Bewerber:innen
 
+# Structure Content Page
+stellenangebote_content_page_title = Stellenangebot
+
 # Konfigurationsformulare
 stellenangebote_config = Einstellungen
 stellenangebote_config_company_name_label = Unternehmens-Name

--- a/lib/stellenangebote.php
+++ b/lib/stellenangebote.php
@@ -67,16 +67,20 @@ class stellenangebote extends \rex_yform_manager_dataset
     public function getApplyForm()
     {
         $fragment = new rex_fragment();
-        echo $fragment->parse('stellenangebote/apply.php');
+        return $fragment->parse('stellenangebote/apply.php');
     }
 
+    public static function getByArticleId($id)
+    {
+        return self::query()->where('article_id', $id)->findOne();
+    }
     
     public static function addContentPage()
     {
 
         rex_extension::register('PAGES_PREPARED', function () {
             $page = new rex_be_page('stellenangebote', rex_i18n::msg('stellenangebote_content_page_title'));
-            $page->setPjax(true);
+            $page->setPjax(false);
             $page->setSubPath(rex_addon::get('stellenangebote')->getPath('pages/content.form.php'));
             $page_controller = rex_be_controller::getPageObject('content');
             $page->setItemAttr('class', "pull-left");

--- a/lib/stellenangebote.php
+++ b/lib/stellenangebote.php
@@ -69,4 +69,19 @@ class stellenangebote extends \rex_yform_manager_dataset
         $fragment = new rex_fragment();
         echo $fragment->parse('stellenangebote/apply.php');
     }
+
+    
+    public static function addContentPage()
+    {
+
+        rex_extension::register('PAGES_PREPARED', function () {
+            $page = new rex_be_page('stellenangebote', rex_i18n::msg('stellenangebote_content_page_title'));
+            $page->setPjax(true);
+            $page->setSubPath(rex_addon::get('stellenangebote')->getPath('pages/content.form.php'));
+            $page_controller = rex_be_controller::getPageObject('content');
+            $page->setItemAttr('class', "pull-left");
+            $page_controller->addSubpage($page);
+        });
+    }
+
 }

--- a/pages/content.form.php
+++ b/pages/content.form.php
@@ -12,16 +12,26 @@ $context = new rex_context([
     'ctype' => $ctype,
 ]);
 
+
 $yform = new rex_yform();
 
-$yform->setObjectparams('form_name', 'table-rex_stellenangebote');
+$stellenangebot = stellenangebote::getByArticleId($articleId);
+
+if(!$stellenangebot) {
+    $stellenangebot = stellenangebote::create();
+}
+
+$yform = $stellenangebot->getForm();
+
 $yform->setObjectparams('form_ytemplate', 'bootstrap');
 $yform->setObjectparams('form_showformafterupdate', 1);
+$yform->setObjectparams('form_action', $context->getUrl());
 
+$yform->setActionField('showtext', array('',rex_view::success('Gespeichert')));
 
 $fragment = new rex_fragment();
 $fragment->setVar('class', 'edit', false);
 $fragment->setVar('title', rex_i18n::msg('stellenangebote_content_page_title'), false);
-$fragment->setVar('body', $yform->getForm(), false);
+$fragment->setVar('body', $stellenangebot->executeForm($yform), false);
 
 return $fragment->parse('core/page/section.php');

--- a/pages/content.form.php
+++ b/pages/content.form.php
@@ -1,0 +1,27 @@
+<?php
+$articleId = rex_request('article_id', 'int');
+$categoryId = rex_request('category_id', 'int');
+$clang = rex_request('clang', 'int');
+$ctype = rex_request('ctype', 'int');
+
+$context = new rex_context([
+    'page' => rex_be_controller::getCurrentPage(),
+    'article_id' => $articleId,
+    'category_id' => $categoryId,
+    'clang' => $clang,
+    'ctype' => $ctype,
+]);
+
+$yform = new rex_yform();
+
+$yform->setObjectparams('form_name', 'table-rex_stellenangebote');
+$yform->setObjectparams('form_ytemplate', 'bootstrap');
+$yform->setObjectparams('form_showformafterupdate', 1);
+
+
+$fragment = new rex_fragment();
+$fragment->setVar('class', 'edit', false);
+$fragment->setVar('title', rex_i18n::msg('stellenangebote_content_page_title'), false);
+$fragment->setVar('body', $yform->getForm(), false);
+
+return $fragment->parse('core/page/section.php');


### PR DESCRIPTION
Stellt die Angaben des Stellenangebots beim passenden Artikel zur Verfügung. So rücken Inhalt und strukturierte Daten zum Stellenangebot näher zueinander.